### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/markhaehnel/sfdl/compare/v0.1.1...v0.2.0) - 2024-10-28
+
+### Other
+
+- *(deps)* bump quick-xml from 0.36.2 to 0.37.0 ([#14](https://github.com/markhaehnel/sfdl/pull/14))
+- *(deps)* bump thiserror from 1.0.64 to 1.0.65 ([#12](https://github.com/markhaehnel/sfdl/pull/12))
+- *(deps)* bump serde from 1.0.210 to 1.0.213 ([#13](https://github.com/markhaehnel/sfdl/pull/13))
+
 ## [0.1.1](https://github.com/markhaehnel/sfdl/compare/v0.1.0...v0.1.1) - 2024-10-09
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,7 +216,7 @@ dependencies = [
 
 [[package]]
 name = "sfdl"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "aes",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "sfdl"
 description = "Parse, encrypt and decrypt SFDL container files"
 authors = ["Mark Hähnel <hello@markhaehnel.de>"]
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 repository = "https://github.com/markhaehnel/sfdl.git"
 keywords = ["sfdl", "parse", "decrypt", "encrypt"]


### PR DESCRIPTION
## 🤖 New release
* `sfdl`: 0.1.1 -> 0.2.0 (⚠️ API breaking changes)

### ⚠️ `sfdl` breaking changes

```
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/enum_variant_added.ron

Failed in:
  variant ParseError:InvalidSfdlDeserialize in /tmp/.tmpFVwyrB/sfdl/src/error.rs:32
  variant ParseError:InvalidSfdlSerialize in /tmp/.tmpFVwyrB/sfdl/src/error.rs:34

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/enum_variant_missing.ron

Failed in:
  variant ParseError::InvalidSfdl, previously in file /tmp/.tmp5V4OpJ/sfdl/src/error.rs:32
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.0](https://github.com/markhaehnel/sfdl/compare/v0.1.1...v0.2.0) - 2024-10-28

### Other

- *(deps)* bump quick-xml from 0.36.2 to 0.37.0 ([#14](https://github.com/markhaehnel/sfdl/pull/14))
- *(deps)* bump thiserror from 1.0.64 to 1.0.65 ([#12](https://github.com/markhaehnel/sfdl/pull/12))
- *(deps)* bump serde from 1.0.210 to 1.0.213 ([#13](https://github.com/markhaehnel/sfdl/pull/13))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).