### PR TITLE
chore: release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/markhaehnel/sfdl/compare/v0.2.0...v0.2.1) - 2024-11-04
+
+### Other
+
+- *(deps)* bump serde from 1.0.213 to 1.0.214 ([#17](https://github.com/markhaehnel/sfdl/pull/17))
+- *(deps)* bump thiserror from 1.0.65 to 1.0.67 ([#16](https://github.com/markhaehnel/sfdl/pull/16))
+
 ## [0.2.0](https://github.com/markhaehnel/sfdl/compare/v0.1.1...v0.2.0) - 2024-10-28
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,7 +216,7 @@ dependencies = [
 
 [[package]]
 name = "sfdl"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "aes",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "sfdl"
 description = "Parse, encrypt and decrypt SFDL container files"
 authors = ["Mark Hähnel <hello@markhaehnel.de>"]
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 repository = "https://github.com/markhaehnel/sfdl.git"
 keywords = ["sfdl", "parse", "decrypt", "encrypt"]


### PR DESCRIPTION
## 🤖 New release
* `sfdl`: 0.2.0 -> 0.2.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.1](https://github.com/markhaehnel/sfdl/compare/v0.2.0...v0.2.1) - 2024-11-04

### Other

- *(deps)* bump serde from 1.0.213 to 1.0.214 ([#17](https://github.com/markhaehnel/sfdl/pull/17))
- *(deps)* bump thiserror from 1.0.65 to 1.0.67 ([#16](https://github.com/markhaehnel/sfdl/pull/16))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).