### PR TITLE
chore: release v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2](https://github.com/markhaehnel/sfdl/compare/v0.2.1...v0.2.2) - 2024-11-11
+
+### Other
+
+- *(deps)* bump thiserror from 1.0.67 to 2.0.3 ([#19](https://github.com/markhaehnel/sfdl/pull/19))
+
 ## [0.2.1](https://github.com/markhaehnel/sfdl/compare/v0.2.0...v0.2.1) - 2024-11-04
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,7 +216,7 @@ dependencies = [
 
 [[package]]
 name = "sfdl"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "aes",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "sfdl"
 description = "Parse, encrypt and decrypt SFDL container files"
 authors = ["Mark Hähnel <hello@markhaehnel.de>"]
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 repository = "https://github.com/markhaehnel/sfdl.git"
 keywords = ["sfdl", "parse", "decrypt", "encrypt"]


### PR DESCRIPTION
## 🤖 New release
* `sfdl`: 0.2.1 -> 0.2.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.2](https://github.com/markhaehnel/sfdl/compare/v0.2.1...v0.2.2) - 2024-11-11

### Other

- *(deps)* bump thiserror from 1.0.67 to 2.0.3 ([#19](https://github.com/markhaehnel/sfdl/pull/19))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).