### PR TITLE
chore: release v0.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.6](https://github.com/markhaehnel/sfdl/compare/v0.2.5...v0.2.6) - 2024-12-30
+
+### Other
+
+- *(deps)* bump quick-xml from 0.37.1 to 0.37.2 (#31)
+- *(deps)* bump serde from 1.0.216 to 1.0.217 (#30)
+
 ## [0.2.5](https://github.com/markhaehnel/sfdl/compare/v0.2.4...v0.2.5) - 2024-12-23
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,7 +216,7 @@ dependencies = [
 
 [[package]]
 name = "sfdl"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "aes",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "sfdl"
 description = "Parse, encrypt and decrypt SFDL container files"
 authors = ["Mark Hähnel <hello@markhaehnel.de>"]
-version = "0.2.5"
+version = "0.2.6"
 edition = "2021"
 repository = "https://github.com/markhaehnel/sfdl.git"
 keywords = ["sfdl", "parse", "decrypt", "encrypt"]


### PR DESCRIPTION
## 🤖 New release
* `sfdl`: 0.2.5 -> 0.2.6 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.6](https://github.com/markhaehnel/sfdl/compare/v0.2.5...v0.2.6) - 2024-12-30

### Other

- *(deps)* bump quick-xml from 0.37.1 to 0.37.2 (#31)
- *(deps)* bump serde from 1.0.216 to 1.0.217 (#30)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).