### PR TITLE
chore: release v0.2.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.10](https://github.com/markhaehnel/sfdl/compare/v0.2.9...v0.2.10) - 2025-03-03
+
+### Other
+
+- *(deps)* bump thiserror from 2.0.11 to 2.0.12 ([#39](https://github.com/markhaehnel/sfdl/pull/39))
+
 ## [0.2.9](https://github.com/markhaehnel/sfdl/compare/v0.2.8...v0.2.9) - 2025-02-24
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,7 +224,7 @@ dependencies = [
 
 [[package]]
 name = "sfdl"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "aes",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "sfdl"
 description = "Parse, encrypt and decrypt SFDL container files"
 authors = ["Mark Hähnel <hello@markhaehnel.de>"]
-version = "0.2.9"
+version = "0.2.10"
 edition = "2021"
 repository = "https://github.com/markhaehnel/sfdl.git"
 keywords = ["sfdl", "parse", "decrypt", "encrypt"]


### PR DESCRIPTION



## 🤖 New release

* `sfdl`: 0.2.9 -> 0.2.10 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.10](https://github.com/markhaehnel/sfdl/compare/v0.2.9...v0.2.10) - 2025-03-03

### Other

- *(deps)* bump thiserror from 2.0.11 to 2.0.12 ([#39](https://github.com/markhaehnel/sfdl/pull/39))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).