### PR TITLE
chore: release v0.2.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.12](https://github.com/markhaehnel/sfdl/compare/v0.2.11...v0.2.12) - 2025-03-31
+
+### Other
+
+- *(deps)* bump quick-xml from 0.37.2 to 0.37.3 ([#43](https://github.com/markhaehnel/sfdl/pull/43))
+
 ## [0.2.11](https://github.com/markhaehnel/sfdl/compare/v0.2.10...v0.2.11) - 2025-03-16
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,7 +224,7 @@ dependencies = [
 
 [[package]]
 name = "sfdl"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "aes",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "sfdl"
 description = "Parse, encrypt and decrypt SFDL container files"
 authors = ["Mark Hähnel <hello@markhaehnel.de>"]
-version = "0.2.11"
+version = "0.2.12"
 edition = "2021"
 repository = "https://github.com/markhaehnel/sfdl.git"
 keywords = ["sfdl", "parse", "decrypt", "encrypt"]


### PR DESCRIPTION



## 🤖 New release

* `sfdl`: 0.2.11 -> 0.2.12 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.12](https://github.com/markhaehnel/sfdl/compare/v0.2.11...v0.2.12) - 2025-03-31

### Other

- *(deps)* bump quick-xml from 0.37.2 to 0.37.3 ([#43](https://github.com/markhaehnel/sfdl/pull/43))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).