### PR TITLE
chore: release v0.2.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.14](https://github.com/markhaehnel/sfdl/compare/v0.2.13...v0.2.14) - 2025-05-04
+
+### Other
+
+- *(deps)* bump quick-xml from 0.37.4 to 0.37.5 ([#49](https://github.com/markhaehnel/sfdl/pull/49))
+- *(deps)* bump rand from 0.9.0 to 0.9.1 ([#47](https://github.com/markhaehnel/sfdl/pull/47))
+
 ## [0.2.13](https://github.com/markhaehnel/sfdl/compare/v0.2.12...v0.2.13) - 2025-04-07
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -223,7 +223,7 @@ dependencies = [
 
 [[package]]
 name = "sfdl"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "aes",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "sfdl"
 description = "Parse, encrypt and decrypt SFDL container files"
 authors = ["Mark Hähnel <hello@markhaehnel.de>"]
-version = "0.2.13"
+version = "0.2.14"
 edition = "2021"
 repository = "https://github.com/markhaehnel/sfdl.git"
 keywords = ["sfdl", "parse", "decrypt", "encrypt"]


### PR DESCRIPTION



## 🤖 New release

* `sfdl`: 0.2.13 -> 0.2.14 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.14](https://github.com/markhaehnel/sfdl/compare/v0.2.13...v0.2.14) - 2025-05-04

### Other

- *(deps)* bump quick-xml from 0.37.4 to 0.37.5 ([#49](https://github.com/markhaehnel/sfdl/pull/49))
- *(deps)* bump rand from 0.9.0 to 0.9.1 ([#47](https://github.com/markhaehnel/sfdl/pull/47))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).