### PR TITLE
chore: release v0.2.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.15](https://github.com/markhaehnel/sfdl/compare/v0.2.14...v0.2.15) - 2025-12-29
+
+### Other
+
+- *(deps)* bump md5 from 0.7.0 to 0.8.0 ([#50](https://github.com/markhaehnel/sfdl/pull/50))
+- *(deps)* bump rand from 0.9.1 to 0.9.2 ([#52](https://github.com/markhaehnel/sfdl/pull/52))
+- *(deps)* bump quick-xml from 0.37.5 to 0.38.3 ([#54](https://github.com/markhaehnel/sfdl/pull/54))
+- *(deps)* bump thiserror from 2.0.12 to 2.0.17 ([#59](https://github.com/markhaehnel/sfdl/pull/59))
+- *(deps)* bump serde from 1.0.219 to 1.0.228 ([#60](https://github.com/markhaehnel/sfdl/pull/60))
+- *(deps)* bump actions/checkout from 4 to 6 ([#61](https://github.com/markhaehnel/sfdl/pull/61))
+
 ## [0.2.14](https://github.com/markhaehnel/sfdl/compare/v0.2.13...v0.2.14) - 2025-05-04
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -233,7 +233,7 @@ dependencies = [
 
 [[package]]
 name = "sfdl"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "aes",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "sfdl"
 description = "Parse, encrypt and decrypt SFDL container files"
 authors = ["Mark Hähnel <hello@markhaehnel.de>"]
-version = "0.2.14"
+version = "0.2.15"
 edition = "2021"
 repository = "https://github.com/markhaehnel/sfdl.git"
 keywords = ["sfdl", "parse", "decrypt", "encrypt"]


### PR DESCRIPTION



## 🤖 New release

* `sfdl`: 0.2.14 -> 0.2.15 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.15](https://github.com/markhaehnel/sfdl/compare/v0.2.14...v0.2.15) - 2025-12-29

### Other

- *(deps)* bump md5 from 0.7.0 to 0.8.0 ([#50](https://github.com/markhaehnel/sfdl/pull/50))
- *(deps)* bump rand from 0.9.1 to 0.9.2 ([#52](https://github.com/markhaehnel/sfdl/pull/52))
- *(deps)* bump quick-xml from 0.37.5 to 0.38.3 ([#54](https://github.com/markhaehnel/sfdl/pull/54))
- *(deps)* bump thiserror from 2.0.12 to 2.0.17 ([#59](https://github.com/markhaehnel/sfdl/pull/59))
- *(deps)* bump serde from 1.0.219 to 1.0.228 ([#60](https://github.com/markhaehnel/sfdl/pull/60))
- *(deps)* bump actions/checkout from 4 to 6 ([#61](https://github.com/markhaehnel/sfdl/pull/61))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).