### PR TITLE
chore: release v0.2.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.16](https://github.com/markhaehnel/sfdl/compare/v0.2.15...v0.2.16) - 2026-05-05
+
+### Other
+
+- *(ci)* add trusted publishing ([#72](https://github.com/markhaehnel/sfdl/pull/72))
+- *(deps)* bump thiserror from 2.0.17 to 2.0.18 ([#64](https://github.com/markhaehnel/sfdl/pull/64))
+- *(deps)* bump quick-xml from 0.38.4 to 0.39.0 ([#63](https://github.com/markhaehnel/sfdl/pull/63))
+
 ## [0.2.15](https://github.com/markhaehnel/sfdl/compare/v0.2.14...v0.2.15) - 2025-12-29
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -233,7 +233,7 @@ dependencies = [
 
 [[package]]
 name = "sfdl"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "aes",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "sfdl"
 description = "Parse, encrypt and decrypt SFDL container files"
 authors = ["Mark Hähnel <hello@markhaehnel.de>"]
-version = "0.2.15"
+version = "0.2.16"
 edition = "2021"
 repository = "https://github.com/markhaehnel/sfdl.git"
 keywords = ["sfdl", "parse", "decrypt", "encrypt"]


### PR DESCRIPTION



## 🤖 New release

* `sfdl`: 0.2.15 -> 0.2.16 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.16](https://github.com/markhaehnel/sfdl/compare/v0.2.15...v0.2.16) - 2026-05-05

### Other

- *(ci)* add trusted publishing ([#72](https://github.com/markhaehnel/sfdl/pull/72))
- *(deps)* bump thiserror from 2.0.17 to 2.0.18 ([#64](https://github.com/markhaehnel/sfdl/pull/64))
- *(deps)* bump quick-xml from 0.38.4 to 0.39.0 ([#63](https://github.com/markhaehnel/sfdl/pull/63))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).