### PR TITLE
chore: release v0.2.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.17](https://github.com/markhaehnel/sfdl/compare/v0.2.16...v0.2.17) - 2026-05-05
+
+### Other
+
+- *(deps)* bump aes from 0.8.4 to 0.9.0 ([#69](https://github.com/markhaehnel/sfdl/pull/69))
+- *(deps)* bump rand from 0.9.2 to 0.10.1 ([#70](https://github.com/markhaehnel/sfdl/pull/70))
+- *(deps)* bump quick-xml from 0.39.0 to 0.39.3 ([#68](https://github.com/markhaehnel/sfdl/pull/68))
+
 ## [0.2.16](https://github.com/markhaehnel/sfdl/compare/v0.2.15...v0.2.16) - 2026-05-05
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,7 +332,7 @@ dependencies = [
 
 [[package]]
 name = "sfdl"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "aes",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "sfdl"
 description = "Parse, encrypt and decrypt SFDL container files"
 authors = ["Mark Hähnel <hello@markhaehnel.de>"]
-version = "0.2.16"
+version = "0.2.17"
 edition = "2021"
 repository = "https://github.com/markhaehnel/sfdl.git"
 keywords = ["sfdl", "parse", "decrypt", "encrypt"]


### PR DESCRIPTION



## 🤖 New release

* `sfdl`: 0.2.16 -> 0.2.17 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.17](https://github.com/markhaehnel/sfdl/compare/v0.2.16...v0.2.17) - 2026-05-05

### Other

- *(deps)* bump aes from 0.8.4 to 0.9.0 ([#69](https://github.com/markhaehnel/sfdl/pull/69))
- *(deps)* bump rand from 0.9.2 to 0.10.1 ([#70](https://github.com/markhaehnel/sfdl/pull/70))
- *(deps)* bump quick-xml from 0.39.0 to 0.39.3 ([#68](https://github.com/markhaehnel/sfdl/pull/68))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).