### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/markhaehnel/sfdl/compare/v0.2.17...v0.3.0) - 2026-07-19
+
+### Added
+
+- add sfdl CLI example and fix DefaultPath decryption ([#84](https://github.com/markhaehnel/sfdl/pull/84))
+- *(crypto)* implement encryption correctness, full field coverage, and atomic operations ([#82](https://github.com/markhaehnel/sfdl/pull/82))
+
+### Other
+
+- *(deps)* bump actions/checkout from 6 to 7 ([#79](https://github.com/markhaehnel/sfdl/pull/79))
+
 ## [0.2.17](https://github.com/markhaehnel/sfdl/compare/v0.2.16...v0.2.17) - 2026-05-05
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,7 +220,7 @@ dependencies = [
 
 [[package]]
 name = "sfdl"
-version = "0.2.17"
+version = "0.3.0"
 dependencies = [
  "aes",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "sfdl"
 description = "Parse, encrypt and decrypt SFDL container files"
 authors = ["Mark Hähnel <hello@markhaehnel.de>"]
-version = "0.2.17"
+version = "0.3.0"
 edition = "2021"
 rust-version = "1.97"
 repository = "https://github.com/markhaehnel/sfdl.git"


### PR DESCRIPTION



## 🤖 New release

* `sfdl`: 0.2.17 -> 0.3.0 (⚠ API breaking changes)

### ⚠ `sfdl` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field SfdlPackage.file_list in /tmp/.tmpf6UZSt/sfdl/src/sfdl.rs:189

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_added.ron

Failed in:
  variant DecryptError:InvalidCiphertextLength in /tmp/.tmpf6UZSt/sfdl/src/error.rs:30

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_missing.ron

Failed in:
  variant EncryptError::EmptyPassword, previously in file /tmp/.tmpVwbtCA/sfdl/src/error.rs:12

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/function_missing.ron

Failed in:
  function sfdl::sfdl::default_xmlns_xsi, previously in file /tmp/.tmpVwbtCA/sfdl/src/sfdl.rs:75
  function sfdl::sfdl::default_xmlns_xsd, previously in file /tmp/.tmpVwbtCA/sfdl/src/sfdl.rs:71

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/module_missing.ron

Failed in:
  mod sfdl::crypto, previously in file /tmp/.tmpVwbtCA/sfdl/src/crypto.rs:1

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_missing.ron

Failed in:
  struct sfdl::sfdl::Package, previously in file /tmp/.tmpVwbtCA/sfdl/src/sfdl.rs:135
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.0](https://github.com/markhaehnel/sfdl/compare/v0.2.17...v0.3.0) - 2026-07-19

### Added

- add sfdl CLI example and fix DefaultPath decryption ([#84](https://github.com/markhaehnel/sfdl/pull/84))
- *(crypto)* implement encryption correctness, full field coverage, and atomic operations ([#82](https://github.com/markhaehnel/sfdl/pull/82))

### Other

- *(deps)* bump actions/checkout from 6 to 7 ([#79](https://github.com/markhaehnel/sfdl/pull/79))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).