### PR TITLE
ci: use cargo-nextest for test runs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,5 +47,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: "1.97"
-      - run: cargo test --locked --all-targets --all-features
+      - uses: taiki-e/install-action@nextest
+      - run: cargo nextest run --locked --all-targets --all-features
+      - run: cargo test --doc --locked --all-features
       - run: cargo doc --no-deps


### PR DESCRIPTION
Updates CI workflow to use cargo-nextest to run tests and cargo test to run doctests.