### PR TITLE
chore: release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/markhaehnel/sfdl/compare/v0.3.0...v0.3.1) - 2026-08-17
+
+### Other
+
+- *(deps)* bump thiserror from 2.0.19 to 2.0.20 ([#90](https://github.com/markhaehnel/sfdl/pull/90))
+- *(deps)* bump aes from 0.9.1 to 0.9.2 ([#88](https://github.com/markhaehnel/sfdl/pull/88))
+- use cargo-nextest for test runs ([#85](https://github.com/markhaehnel/sfdl/pull/85))
+
 ## [0.3.0](https://github.com/markhaehnel/sfdl/compare/v0.2.17...v0.3.0) - 2026-07-19
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,7 +220,7 @@ dependencies = [
 
 [[package]]
 name = "sfdl"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "aes",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "sfdl"
 description = "Parse, encrypt and decrypt SFDL container files"
 authors = ["Mark Hähnel <hello@markhaehnel.de>"]
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 rust-version = "1.97"
 repository = "https://github.com/markhaehnel/sfdl.git"


### PR DESCRIPTION



## 🤖 New release

* `sfdl`: 0.3.0 -> 0.3.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.1](https://github.com/markhaehnel/sfdl/compare/v0.3.0...v0.3.1) - 2026-08-17

### Other

- *(deps)* bump thiserror from 2.0.19 to 2.0.20 ([#90](https://github.com/markhaehnel/sfdl/pull/90))
- *(deps)* bump aes from 0.9.1 to 0.9.2 ([#88](https://github.com/markhaehnel/sfdl/pull/88))
- use cargo-nextest for test runs ([#85](https://github.com/markhaehnel/sfdl/pull/85))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).